### PR TITLE
Derive reverse _supersedes references from @deprecated.superseded_by

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Lint
       run: |
-        python -m pip install basedpyright ruff
+        python -m pip install "basedpyright ~= 1.39.9" "ruff ~= 0.15.20"
         make lint-github
 
   build-check:

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,19 @@ pip-update:
 	# Update Python
 	python3 -m venv --upgrade .venv
 	# Install or update all development time pip dependencies
-	python -m pip install -U basedpyright ruff flit
+	# basedpyright and ruff are pinned in pyproject.toml's "dev" extra so that
+	# local linting matches continuous integration
+	python -m pip install -U ".[dev]" flit
 
 lint:
 	@./scripts/ensure-venv.sh
-	# Requires ruff and basedpyright: python -m pip install basedpyright ruff
+	# Requires ruff and basedpyright: python -m pip install ".[dev]"
 	ruff check
 	basedpyright
 	ruff format --check --diff
 
 lint-github:
-	# Requires ruff and basedpyright: python -m pip install basedpyright ruff
+	# Requires ruff and basedpyright: python -m pip install ".[dev]"
 	ruff check --output-format=github
 	basedpyright
 	ruff format --check --diff

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # OCSF Schema Compiler
+
 This is a Python library and command-line tool for compiling the Open Cybersecurity Schema Framework (OCSF) schema, specifically the schema at https://github.com/ocsf/ocsf-schema.
 
 This project is published to PyPI: [ocsf-schema-compiler · PyPI](https://pypi.org/project/ocsf-schema-compiler/).
 
 ## Getting started
+
 There are three ways to use the OCSF Schema Compiler:
+
 1. As a command-line tool, installed from PyPI.
 2. As a library, installed from PyPI.
 3. As a developer working on this project.
@@ -12,7 +15,9 @@ There are three ways to use the OCSF Schema Compiler:
 Python version 3.14 or later is required. The core project code does not require any dependencies, though optional developer dependencies are used (see below).
 
 ## Using ocsf-schema-compiler as a command-line tool
+
 Create a virtual environment then install with `pip`. For example:
+
 ```shell
 python3 -m venv .venv
 source ./.venv/bin/activate
@@ -20,17 +25,21 @@ python -m pip install ocsf-schema-compiler
 ```
 
 Running from this environment is now a matter of calling `ocsf-schema-compiler`:
+
 ```shell
 ocsf-schema-compiler -h
 ```
 
 The basic usage is passing the base directory of a schema to the compiler and capturing the output to a file.
+
 ```shell
 ocsf-schema-compiler path/to/ocsf-schema > schema.json
 ```
 
 ## Using ocsf-schema-compiler as a library
+
 Create a virtual environment then install with `pip`. For example:
+
 ```shell
 python3 -m venv .venv
 source ./.venv/bin/activate
@@ -38,6 +47,7 @@ python -m pip install ocsf-schema-compiler
 ```
 
 The compiler is implemented in the `SchemaCompiler` class. The class constructor accepts the same options as the command-line tool. The class's `compile` method does the heavy lifting, returning a `dict` containing the compiled schema. Specifically, `compiler` returns an `ocsf_schema_compiler.jsonish.JObject`, which is a type alias for JSON-compatible `dict`.
+
 ```python
 from pathlib import Path
 from ocsf_schema_compiler.compiler import SchemaCompiler
@@ -52,22 +62,31 @@ The returned `compile_version` 1 structure is documented in [Compiled schema for
 See [`ocsf_schema_compiler.__main__`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/src/ocsf_schema_compiler/__main__.py) for a working example.
 
 ## Developing ocsf-schema-compiler
+
 The recommended way to work on OCSF projects is to create fork in your own GitHub profile or organization. Create your fork of [this repo](https://github.com/ocsf/ocsf-schema-compiler) using the [GitHub CLI](https://cli.github.com/) tool (or, more painfully, manually).
 
-This project requires **Python 3.14 or later**; otherwise, it has no runtime dependencies. This means you can run it directly from a cloned repo's `src` directory without creating a virtual environment.
+This project requires **Python 3.14 or later** and uses [basedpyright](https://docs.basedpyright.com/latest/) for type checking and [Ruff](https://docs.astral.sh/ruff/) for linting and code formatting. There are no runtime dependencies.
+
+This project intentionally uses unpinned versions of the `basedpyright` and `ruff` tool so we use their evolving lint rules. Because of this, it is a best practice to update to the latest versions of these tools and fixing newly identified issues before making other changes. Lint and formatting chances should ideally be placed in their own pull requests.
 
 ```shell
-cd path/to/ocsf-schema-compiler
-cd src
-python3 -m ocsf_schema_compiler ~/path/to/ocsf-schema > ~/path/to/output/schema.json
+# Get / update pip dependencies and run the lint tools
+make pip-update lint
+# If issues are found, create a branch to fix these issues
+git checkout -b lint-fixes
+# Fix the issues
+# Create a PR
 ```
 
+_**NOTE:** Please avoid "fixing" lint issue with ignore directives._
+
+These ignore directives should only be used when there is no good way to fix this issue. For example, the tests use `# pyright: ignore[reportImplicitRelativeImport]` to import from other test modules since I couldn't find another way to do this.
+
 This project includes regression tests in the `tests` directory, built using the `unittest` library. These can also be run without a virtual environment so long as `python3` refers to **Python 3.14 or later**. The tests can be run with the [`Makefile`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/Makefile) target `tests`.
+
 ```shell
 make tests
 ```
-
-This project uses [basedpyright](https://docs.basedpyright.com/latest/) for type checking and [Ruff](https://docs.astral.sh/ruff/) for linting and code formatting.
 
 Basedpyright was picked as an alternative to Pylance because I'm using the open-source and telemetry-free [VSCodium](https://vscodium.com/) variation of VS Code. The Microsoft-proprietary Pylance extension (part of the Python extension) does not work in VSCodium by design. Basedpyright also offers other benefits: it is strict by default and includes additional type checking rules. Extensions are available for both VSCodium and VS Code; in both cases look for **"BasedPyright"** by detachhead. Use in VS Code does, however, take a little more work. I hope Pyright fans — and especially VS Code users — will find this workable, and perhaps consider using the privacy-focused VSCodium themselves.
 
@@ -76,6 +95,7 @@ The choice of Ruff should be less controversial: it is the current favorite for 
 Use of these tools requires a virtual environment. With the virtual environment activated, the linting and formatting can be run with the [`Makefile`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/Makefile) target `lint`.
 
 Integrating basedpyright and Ruff with your editor is recommended. In both cases, these tools will pick up the configuration in this project's [`pyproject.toml`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/pyproject.toml) file.
+
 * [Editor integration | Ruff](https://docs.astral.sh/ruff/editors/)
 * [IDEs - basedpyright](https://docs.basedpyright.com/latest/installation/ides/)
 
@@ -87,24 +107,34 @@ python3 -m venv .venv
 source ./.venv/bin/activate
 
 # Install the tools
-python -m pip install ".[dev]"
+# The make pip-update target gets / updates the needed dependencies
+make pip-update
 
 # Now the lint target will work
 make lint
 ```
 
-The `dev` extra pins basedpyright and Ruff to a minor version so that local linting matches continuous integration. Both tools add and promote rules in minor releases, which can otherwise fail the lint job on unchanged code. Raise the bounds in [`pyproject.toml`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/pyproject.toml) deliberately, along with any resulting lint fixes.
+To run local development changes, use of a virtual environment is recommended through use of the `pip` tool's editable requirement feature.
 
-Also, with a virtual environment, a local install can be used to run the compiler.
 ```shell
 # A standard Python virtual environment works fine
 python3 -m venv .venv
 source ./.venv/bin/activate
 
+# Install project as an editable requirement ("develop mode")
 python -m pip install -e .
 ```
 
+Since this repo has no runtime dependencies, you can also run it directly from a cloned repo's `src` directory without creating a virtual environment. This is more of a novelty than a best practice as it skips installation of the lint and format tools.
+
+```shell
+cd path/to/ocsf-schema-compiler
+cd src
+python3 -m ocsf_schema_compiler ~/path/to/ocsf-schema > ~/path/to/output/schema.json
+```
+
 To ensure the project can be built for distribution, the `build-check` target in the [`Makefile`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/Makefile) can be used. This project is built with [Flit](https://flit.pypa.io/), a modern minimal build and publishing tool. It can be run locally to ensure the project remains buildable. This target runs `flit build` and `flit install` to build the package and install it locally, and then runs `ocsf-schema-compiler -h` to verify it works.
+
 ```shell
 # Create virtual environment if it doesn't already exist
 python3 -m venv .venv
@@ -118,13 +148,17 @@ make build-check
 ```
 
 ## Continuous integration
+
 The continuous integration is done via a GitHub action in [`.github/workflows/ci.yaml`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/.github/workflows/ci.yaml). This action uses the [`Makefile`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/Makefile) targets `test`, `lint-github`, and `build-check`. (The `lint-github` target is a minor variation of the `lint` target with Ruff's GitHub output format option.)
 
 ## Publishing
+
 Publishing details are covered in [`docs/publishing.md`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/docs/publishing.md).
 
 ## Copyright
+
 Copyright © OCSF a Series of LF Projects, LLC. See [NOTICE](https://github.com/ocsf/ocsf-schema-compiler/blob/main/NOTICE) for details.
 
 ## License
+
 This project is distributed under the Apache License Version 2.0. See [LICENSE](https://github.com/ocsf/ocsf-schema-compiler/blob/main/LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ python3 -m venv .venv
 source ./.venv/bin/activate
 
 # Install the tools
-python -m pip install basedpyright ruff
+python -m pip install ".[dev]"
 
 # Now the lint target will work
 make lint
 ```
+
+The `dev` extra pins basedpyright and Ruff to a minor version so that local linting matches continuous integration. Both tools add and promote rules in minor releases, which can otherwise fail the lint job on unchanged code. Raise the bounds in [`pyproject.toml`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/pyproject.toml) deliberately, along with any resulting lint fixes.
 
 Also, with a virtual environment, a local install can be used to run the compiler.
 ```shell

--- a/docs/diffs-historical.md
+++ b/docs/diffs-historical.md
@@ -5,11 +5,13 @@ This historical document records differences encountered while replacing the ocs
 This document refers to the ocsf-server v3 compiler as the "legacy compiler" and its output as the "legacy format". It refers to the ocsf-schema-compiler as the "new compiler" and its output as the "new format", reflecting the terminology used during the replacement project.
 
 ## Legacy exported schema vs new format
+
 The ocsf-server's `/export/schema` format does not return all details, requiring use of various `/api` endpoints to retrieve the entire schema. The new format puts everything together.
 
 This section focuses on how the current format differs from the legacy compiler output.
 
 For reference, the legacy `/export/schema` API returns the following top-level structure:
+
 ```json5
 {
   "base_event": {}, // note: this is broken in current version 3.1.0 (it is not fully processed)
@@ -22,6 +24,7 @@ For reference, the legacy `/export/schema` API returns the following top-level s
 ```
 
 The main differences at this level are:
+
 - The addition of `compile_version` with value 1. The legacy schema has an implied version of 0.
 - The addition of `categories`, `profiles`, and `extensions` information. The legacy schema requires separate API calls to retrieve this information.
 - The dictionary is not split into `dictionary_attributes` and `types` but rather presented similar to the metaschema format.
@@ -29,60 +32,72 @@ The main differences at this level are:
 The `/api/categories`, `/api/extensions`, and `/api/profiles` APIs are needed to get the remaining details of the schema.
 
 ## Potential extension class uid collision
+
 Class UIDs are meant to be scoped by category. All UIDs in an extension are meant to be scoped by the extension. However there is one situation where this breaks down due to the math used to create the extension-scoped UIDs.
 
 The colliding situation is the following:
+
 1. An extension has a category with a UID that is the same a base schema category. Normally extension categories using the same UID as a base category is fine.
 2. The extension has two classes, one of which uses the base schema category above and the other uses the extension category. Both of these classes use the same UID. Normally classes that use the same UID is fine so long as use different categories.
 
 The problem that formula creating an extension-scoped category UID overlaps with the formula for creating an extension-scoped class UID.
 
 These are the formulas.
+
 - Extension-scoped category UID: (100 * category UID)
 - Category-scoped class UID:
-    - For base schema classes:
-        - (1000 * category UID) + class UID
-    - For extension classes that use base schema categories:
-        - (1000 * ((100 * extension UID) + base category UID)) + class UID
-    - For extension classes that use extension categories:
-        - (1000 * ((100 * extension UID) + unscoped category UID)) + class UID
+  - For base schema classes:
+    - (1000 * category UID) + class UID
+  - For extension classes that use base schema categories:
+    - (1000 *((100* extension UID) + base category UID)) + class UID
+  - For extension classes that use extension categories:
+    - (1000 *((100* extension UID) + unscoped category UID)) + class UID
 
 The flaw is that for extension classes, both base category UIDs and extension category UIDs are both treated as if they come from the extension.
 
 The old compiler does not detect this situation and generates extension classes with the same UID values. The new compiler issues a warning when extension category UIDs match a base category UID, as well as an error for class UID collisions. Indeed, the new compiler checks for collisions with all UIDs: extension UIDs, categories (after extension-scoping), and class UIDs (after extension-scoping).
 
 ## Other differences
+
 This section cover a laundry list of other differences. Many of these are addressed in the ocsf-server [Bug fixes](https://github.com/ocsf/ocsf-server/pull/169) pull request, created as a way to more easily compare file differences during development of the new compiler.
 
 ### Difference 1: broken top-level base_event
+
 The the base event class at legacy output's `base_event` key is not fully processed. This is a longstanding regression bug. Note that the base event class in the legacy schema's `classes` at `classes.base_event` is not fully processed.
 
 ### Difference 2: profiles are sorted
+
 The new compiler sorts the various `profiles` string arrays. With the legacy compiler, the order was non-deterministic.
 
 ### Difference 3: reverse merging of extension class and object attributes to dictionary
+
 The legacy compiler reverse merged details of extension class and object attributes to the base dictionary. It is unclear why this was done. The new compiler does not do this.
 
 Quirks and bugs I've seen caused by this weirdness:
+
 - The `caption`, `description`, `group`, `profile`, and `requirement` values from classes and/or objects propagated back to dictionary attributes. I did not notice these cases propagated onward to other classes and objects.
 - The `group` values propagated from a class or object to the dictionary and then to another class or object.
 
 These should be be non-issues. The cases above do not affect encodings or event validation. However, due to weirdness of this bug, there may well be a private extension out there that propagates a material change.
 
 ### Difference 4: profile consolidation in classes and objects
+
 The `profiles` attribute in classes and objects is a consolidation of all its own profiles and all child objects. The legacy compiler implementation did not fully consolidate the profiles of all objects. Interestingly, this did not affect the consolidation of profiles in `classes`.
 
 With the new compiler, `profiles` field in objects includes those of all children. The following objects are affected: `actor`, `affected_package`, `application`, `cis_benchmark_result`, `idp`, `metadata`, `remediation`, `startup_item`, and `vulnerability`.
 
 ### Difference 5: dictionary data type extension information
+
 The new compiler adds `extension` and `extension_id` attributes to dictionary data types coming from extensions. This is done for consistency with dictionary attributes.
 
 ### Difference 6: type_name set properly for class and object refined types
+
 In dictionary types that are subtypes, `type` refers to the base type's name (e.g., `string_t`), and `type_name` refers to the base type's caption (e.g., "String").
 
 Class and object attributes are allowed to refine the type of their attributes to a subtype or the original. In these cases, legacy compiler was incorrectly populating the attribute details with the dictionary attribute's original base type and caption, rather than the refined type's base type and caption.
 
 ### Difference 7: handling of extension-scoped names
+
 As of v0.9.8, the new compiler now uses extension-scoped names the same way as the old compiler with two differences: extension defined dictionary types and other extension names that collide with base schema names.
 
 First, dictionary types are handled different. The old compiler uses unscoped names for dictionary data types defined in extensions. This opens up the possibility new collisions should a future base schema version also add a dictionary data type with the same name. By default, the new compiler uses extension-scoped names for dictionary types defined in extensions other than platform extensions. The dictionary types added in platform extensions remain unscoped for backwards compatibility.
@@ -92,18 +107,22 @@ This behavior can be changed with the `-u, --unscoped-dictionary-types` option. 
 Second, extension items with names that collide with base schema names cause an error by default, since this causes uses in the extension to _shadow_ the same item in the base schema, preventing the extension from using the base schema version of this item. (Remember that extensions refer to both base schema names and their own item names without a scope.) This behavior can be changed with the `-a, --allow-shadowing` option. When shadowed names are enabled, the new compiler will still issue a warning since additions to existing schema should still avoid these name collisions.
 
 ### Difference 8: class and object attribute profile change
+
 The new compiler uses `profiles` in class and object attributes. The allows multiple profiles to affect the same attribute. This amounts to design flaw in the legacy compiler output format since it was always possible to define multiple profiles that affect the same attribute.
 
 ### Difference 9: extension are processed deterministically
+
 The new compiler processes extensions in a deterministic manner. This is useful in cases where extensions extend or patch items in other extensions.
 
 Processing order:
+
 1. Platform extensions — those in the base schema's `extensions` directory — are processed first, in ascending extension UID order.
 2. Other extensions are processed in ascending extension UID order.
 
 By contract, the old compiler processed extension in a partial order. Each paths in the `SCHEMA_EXTENSION` environment variable was considered in order, however the extensions inside each path were not processed in any sort order.
 
 ### Difference 10: undocumented dictionary attribute overwrite flag
+
 The new compiler removes support for the undocumented `overwrite` property of dictionary attributes.
 
 Note that the dictionary attribute `overwrite` property has never been supported by the metaschema. I suspect that the "overwrite" property has never been actively used.
@@ -111,15 +130,17 @@ Note that the dictionary attribute `overwrite` property has never been supported
 The old compiler allowed modification of dictionary attributes with this property. However, this creates the possibility of incompatible schemas.
 
 ### Difference 11: extension names that shadow base schema names
+
 Extension names that that can shadow base schema names are an error by default.
 
 Shadowing can occur with the following kinds of extension defined items:
+
 - Category names
 - Class names
 - Object names
 - Dictionary attribute names
 - Dictionary type names
-    - This applies to non-platform (_private_) extension when the `-u`, `--unscoped-dictionary-types` option is _not_ enabled (the default). Dictionary type names that collide with the base schema are always an error for platform extensions, and are an error for non-platform (_private_) extensions when the `-u`, `--unscoped-dictionary-types` is enabled.
+  - This applies to non-platform (_private_) extension when the `-u`, `--unscoped-dictionary-types` option is _not_ enabled (the default). Dictionary type names that collide with the base schema are always an error for platform extensions, and are an error for non-platform (_private_) extensions when the `-u`, `--unscoped-dictionary-types` is enabled.
 - Profile names
 
 With the definition of an extension all names are unscoped. There is no way to distinguish between the base schema version of a name and an extension version of with the same name. When shadowing is enabled, the extension can _only_ use their version of the named item.
@@ -129,6 +150,7 @@ This behavior can be changed with the `-a`, `--allow-shadowing` compiler option.
 **TODO:** Should class names be checked for shadowing? These don't seem to be used anywhere. This check will be left for now pending feedback from the community.
 
 ### Difference 12: extension profiles without extension-scope
+
 Most extension-defined items are referenced without an extension-scope, however when profile names are referenced in the extension class and object top-level `profiles` attribute, they are typically referenced _with_ an extension-scope.
 
 When an extension-define profile is referenced _without_ a scope, things get messy. The old compiler simply keeps the unscoped profile name, causing a mismatch between the profile's name in attributes that are enabled by the profile, and the name of the profile in the top-level class or object `profiles` property.
@@ -136,6 +158,7 @@ When an extension-define profile is referenced _without_ a scope, things get mes
 When the new compiler encounters an unscoped profile name that is defined in the extension, it adds the extension-scope to the name. This fix-up avoids the name mismatch caused by the old compiler.
 
 #### Include files and extension-scoped profiles
+
 Profile are also typically implemented using the magic `$include` attribute name in class and object definition with a value that is a relative path. For extensions, the include file handling always looks for this file _first_ relative to the extension's base directory (where the `extension.json` file is at), and next in the base schema directory. (Both the old and new compilers share this behavior.)
 
 The old compiler's extension-define profile name mismatch above is further compounded by always pulling in the extension-define include file. In other words, if an extension tried to define a shadowed, extension-specific version of a profile with the same name as a base class, but one in one case wanted an extension class or object to use the base schema profile, it wouldn't work. Although class or object would have the base schema's profile name in its top-level `profiles` attribute, the details included with the `$include` directive would pull in the extension-specific attributes.
@@ -143,12 +166,15 @@ The old compiler's extension-define profile name mismatch above is further compo
 In short, the old compiler's approach is broken in this case. The new compiler tries to do something sensible, allowing unscoped extension-define profile name references to work like every other extension item name reference: unscoped.
 
 ### Difference 13: patched class and object top-level `profiles` property with `null` value
+
 In patched classes and objects that end up with no profiles (the top-level profiles), the new compiler leaves out the `profiles` top-level property, while the old compiler emits `"profiles": null`. This is only a textual difference as there is no logical difference between a `null` value and a missing property.
 
 ## Errors detected by new compiler
+
 The new compiler is stricter than the legacy compiler. Below are the more notable errors.
 
 ### Error: extension dictionary type name collision with base schema dictionary type
+
 Dictionary types defined in extensions other than platform extension are now extension-scoped by default. Dictionary types defined in platform extension remain unscoped for backwards compatibility. When the unscoped dictionary types option is enabled, name collisions with the base dictionary types is an error.
 
 If you are maintaining an extension, and this error occurs when compiling with a new version of the base schema, this means your extension is no longer compatible with the base schema from that version and forward. Your only options are to use a different dictionary type name in your extensions (a backwards incompatible change that _might_ be tolerable in your organization's specific usage), or create your own incompatible fork of the base schema. In other words, you're stuck and there is no good path forward.
@@ -156,4 +182,5 @@ If you are maintaining an extension, and this error occurs when compiling with a
 This is new behavior with v0.9.8. The old compiler allowed modifying base schema dictionary types, silently allowing the possibility to create a schema incompatible with a schema compiled without your extension.
 
 ### Error: unique ID collision
+
 The new compiler checks for unique ID collisions in categories, classes, and extensions.

--- a/docs/format.md
+++ b/docs/format.md
@@ -91,10 +91,13 @@ Deprecated definitions contain an `@deprecated` object:
 {
   "@deprecated": {
     "since": "1.5.0",
-    "message": "Use the replacement definition instead."
+    "message": "Use the replacement definition instead.",
+    "superseded_by": ["replacement"]
   }
 }
 ```
+
+`superseded_by` names the replacement definitions, if any. Entries are names rather than captions: an attribute or enumeration key in the same context, a class or object name, or a dotted path into one such as `email.uid`. An empty array means the definition was removed with no replacement.
 
 Deprecation metadata may occur on classes, objects, attributes, dictionary attributes, profiles, and enumeration entries.
 
@@ -423,6 +426,7 @@ Browser mode keeps the complete normal format and adds information in these broa
 - Top-level `browser_mode?`, `all_classes`, and `all_objects` properties. The `all_*` tables contain concise entries for all definitions, including hidden and abstract definitions that normal output omits.
 - Reverse `_links` from dictionary attributes, objects, and profiles to the classes or objects that use them. Link entries carry display and navigation details such as group, type, caption, attribute keys, extension, and deprecation status.
 - Attribute provenance such as `_source`, patch provenance such as `_patched_by_extensions` and `_patched_by_extension_ids`, observable-kind metadata in `_observable_kind`, and reverse enum-sibling information in `_sibling_of`.
+- Reverse `_supersedes` from a replacement definition back to the deprecated definitions that name it in their `@deprecated.superseded_by`. Each entry carries the deprecated definition's name in `type` and its `since` version, so the browser can show on a live definition which deprecated definition it replaces. Entries are sorted by `type` and are scoped to the context holding the deprecation, so a class- or object-local deprecation does not mark a replacement elsewhere.
 - Fully compiled profile attributes, which normal mode intentionally removes after merging them into classes and objects.
 
 Properties beginning with `_` and the browser-specific lookup tables are compiler UI metadata, not part of the event schema needed for ordinary validation, enrichment, or schema inspection.

--- a/docs/legacy_format.md
+++ b/docs/legacy_format.md
@@ -1,7 +1,9 @@
 # Legacy compiled schema format
+
 This is not a comprehensive document. It was created during development of this project to help understand the existing layout and formatting details, some of which are (were) quite unintuitive.
 
 Top level structure:
+
 ```json5
 {
   "base_event": {},  // "item" format
@@ -14,16 +16,19 @@ Top level structure:
 ```
 
 ## Extension names that are scoped
+
 Extensions create names (JSON object keys) that are sometimes (but annoyingly, not always) scoped by the extension name with the pattern `extension-name/item-name`.
 
 Of these, the only one that must be maintained in any future schema format are extension profile names.
 
-### Extension profiles in classes and dictionary attributes.
+### Extension profiles in classes and dictionary attributes
+
 Extension profiles are scoped when they appear a class `profiles` array and dictionary attributes.
 
 This needs to be maintained. These scopes names DO appear in concrete events.
 
 ### Extension class and object names
+
 Extension classes use a scoped name for keys under `classes`, but _not_ for their own `name` attributes.
 
 Extension scoped class names are visible in the browser UI on the classes pages (URL path `/classes`). However, concrete events do not use this form of class names. The closest concrete event attribute would be `class_name`, the enum sibling of `class_uid`, however `class_name` is populated with a class's `caption`.
@@ -33,6 +38,7 @@ Similarly, extension scoped object names are visible in the browser UI on the ob
 This does not seem like it needs to be maintained in a future format. These scoped names do not appear in concrete events.
 
 ### Extension object types in class attributes and dictionary attributes
+
 Extension object type names in class and dictionary attributes values are scoped. These are class attribute `object_type` values.
 
 This does not seem like it needs to be maintained in a future format, unless we really want extension items to have their own namespaces (though this isn't always the case in the current format).
@@ -46,6 +52,7 @@ These scoped names do not appear in concrete events.
 This does not seem like it needs to be maintained in a future format.
 
 ### Extension dictionary attributes in dictionary
+
 Extension dictionary attributes are scoped in the dictionary itself.
 
 These scoped names do not appear in the browser UI.
@@ -57,6 +64,7 @@ This does not seem like it needs to be maintained in a future format.
 ## Extension names that are not scoped
 
 # Extension dictionary attributes in classes and objects
+
 Extension dictionary attributes in classes and objects are not scoped when used in classes and objects. These names occur in `attributes` and `constraints`.
 
 NOTE: Due to extension patching of classes and objects, these extension attributes can occur both in extension defined classes and object _and_ base schema classes and objects.
@@ -64,6 +72,7 @@ NOTE: Due to extension patching of classes and objects, these extension attribut
 This means that dictionary attributes are not scoped. They must be unique everywhere.
 
 # Extension dictionary types
+
 Dictionary types (types that not objects) defined in extensions are not scoped for any usage.
 
 (Further, these types are not annotated with `extension` and `extension_id` as with other extension defined things.)

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -55,7 +55,7 @@ source ./.venv/bin/activate
 # Running tests before installing anything ensure this remains true
 make tests
 
-python -m pip install basedpyright ruff flit
+python -m pip install ".[dev]" flit
 make lint
 make build-check
 ```

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,4 +1,5 @@
 # Publishing ocsf-schema-compiler
+
 This project publishes the **ocsf-schema-compiler** package to PyPI. We can also manually publish to TestPyPI.
 
 This project uses [Flit](https://flit.pypa.io/) to build package distributions, but not for publishing. Publishing is done via GitHub releases, utilizing the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) action.
@@ -10,16 +11,19 @@ The publishing flow requires the project's version to be bumped up, along with c
 We can also manually trigger a test publish that works the same way, except that it publishes to TestPyPI.
 
 ## Publishing step 1: update project version
+
 The version is defined in the `__version__` variable in [`src/ocsf_schema_compiler/__init__.py`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/src/ocsf_schema_compiler/__init__.py).
 
 Updating the version requires a normal pull request.
 
 ## Publishing step 2 (optional): create git tag and test publish
+
 A Git tag must be created with the same version with a "v" prefix. This can be created during a release or beforehand via `git` on the command line.
 
 Creating a tag before release allows us to manually publish to TestPyPI at [ocsf-schema-compiler · TestPyPI](https://test.pypi.org/project/ocsf-schema-compiler/) using this repo's "Test publish package to TestPyPI" GitHub action defined in [`.github/workflows/test-publish.yaml`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/.github/workflows/test-publish.yaml). The test-publish action requires the `testpypi` GitHub environment.
 
 To create a new tag on the command line, navigate to a local cloned of this repo's `main` branch (not a fork), then use commands similar to the following example for version 1.0.0:
+
 ```shell
 # Create a nice annotated tag with a message
 git tag v1.0.0 -a -m "Release version 1.0.0"
@@ -36,9 +40,11 @@ git push origin --tags
 To trigger the test publish action, run "Test publish package to TestPyPI" for the `main` branch from this repo's [Actions](https://github.com/ocsf/ocsf-schema-compiler/actions) page.
 
 ## Publishing step 3: release
+
 Create a new release with a tag or select a draft release on the [Releases](https://github.com/ocsf/ocsf-schema-compiler/releases) page, then click "Publish release". This will trigger the GitHub action in [`.github/workflows/publish.yaml`](https://github.com/ocsf/ocsf-schema-compiler/blob/main/.github/workflows/publish.yaml) that publishes the package to PyPI. The publish action requires the `pypi` GitHub environment.
 
 ## Optional: manually checking everything
+
 These steps are optional. The continuous integration and publish actions have this covered. However, for the paranoid, we can manually double-check everything locally.
 
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,16 +32,16 @@ Issues = "https://github.com/ocsf/ocsf-schema-compiler/issues"
 [project.scripts]
 ocsf-schema-compiler = "ocsf_schema_compiler.__main__:main"
 
-# Development tool versions are pinned to a minor version so that continuous
-# integration is reproducible. Ruff and basedpyright add and promote rules in minor
-# releases, which would otherwise fail the lint job on unchanged code. Raise these
-# bounds deliberately, along with any resulting lint fixes.
+# Development tool versions are deliberately unpinned to use the latest rules.
+# As a best practice, run `make pip-update lint` before making other changes,
+# putting any lint and formatting changes in a their own PR.
 [project.optional-dependencies]
-dev = ["basedpyright ~= 1.39.9", "ruff ~= 0.15.20"]
+dev = ["basedpyright", "ruff"]
 
 # This project uses basedpyright rather than pyright. This is for two reasons:
-#   1. I uses vscodium, and the M$ proprietary PyLance extension does not work in
-#      vscodium. The basedpyright extension is the current best alternative.
+#   1. I uses vscodium, and the M$ proprietary PyLance extension (a dependency
+#      of pyright) does not work in vscodium. The basedpyright extension is
+#      the current best alternative.
 #   2. The rules and defaults in basedpyright are bit more strict.
 [tool.basedpyright]
 # Not sure if implicit string concatenation is a great idea,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,12 @@ Issues = "https://github.com/ocsf/ocsf-schema-compiler/issues"
 [project.scripts]
 ocsf-schema-compiler = "ocsf_schema_compiler.__main__:main"
 
+# Development tool versions are pinned to a minor version so that continuous
+# integration is reproducible. Ruff and basedpyright add and promote rules in minor
+# releases, which would otherwise fail the lint job on unchanged code. Raise these
+# bounds deliberately, along with any resulting lint fixes.
 [project.optional-dependencies]
-dev = ["basedpyright", "ruff"]
+dev = ["basedpyright ~= 1.39.9", "ruff ~= 0.15.20"]
 
 # This project uses basedpyright rather than pyright. This is for two reasons:
 #   1. I uses vscodium, and the M$ proprietary PyLance extension does not work in

--- a/src/ocsf_schema_compiler/compiler.py
+++ b/src/ocsf_schema_compiler/compiler.py
@@ -1957,7 +1957,9 @@ class SchemaCompiler:
                     replacement = self._find_class_or_object(base_name)
                     if replacement is None:
                         continue
-                    self._add_supersedes_marker(replacement, deprecated_name, deprecated)
+                    self._add_supersedes_marker(
+                        replacement, deprecated_name, deprecated
+                    )
 
     def _add_enum_value_supersedes(self) -> None:
         """
@@ -2020,8 +2022,7 @@ class SchemaCompiler:
         put_non_none(entry, "since", deprecated.get("since"))
         supersedes = j_array(target.setdefault("_supersedes", []))
         if not any(
-            j_object(existing).get("type") == deprecated_name
-            for existing in supersedes
+            j_object(existing).get("type") == deprecated_name for existing in supersedes
         ):
             supersedes.append(entry)
             self._sort_supersedes(supersedes)

--- a/src/ocsf_schema_compiler/compiler.py
+++ b/src/ocsf_schema_compiler/compiler.py
@@ -214,6 +214,11 @@ class SchemaCompiler:
 
         self._finish_attributes()
 
+        if self.browser_mode:
+            self._add_local_attribute_supersedes()
+            self._add_item_supersedes()
+            self._add_enum_value_supersedes()
+
         output = self._create_compile_output()
 
         logger.info("Compiled schema base version: %s", self._version)
@@ -1845,8 +1850,194 @@ class SchemaCompiler:
             self._add_common_dictionary_attribute_links()
             self._add_class_dictionary_attribute_links()
             self._add_object_dictionary_attribute_links()
+            self._add_dictionary_attribute_supersedes()
         self._enrich_and_validate_dictionary_types()
         self._add_datetime_sibling_dictionary_attributes()
+
+    def _add_dictionary_attribute_supersedes(self) -> None:
+        """
+        Build the reverse of the "@deprecated.superseded_by" references for
+        dictionary attributes. For each deprecated dictionary attribute that names
+        its replacement(s), attach a "_supersedes" marker onto the replacement's
+        dictionary attribute so the schema browser can show, on the live attribute,
+        which deprecated attribute it replaces. This runs before attributes are
+        merged into classes/objects (in _finish_attributes), so the marker
+        propagates to those copies too.
+        """
+        if not self.browser_mode:
+            return
+
+        dictionary_attributes = dictionary_attribute_definitions(self._dictionary)
+        for deprecated_name, deprecated_attribute in dictionary_attributes.items():
+            deprecated_attribute = j_object(deprecated_attribute)
+            deprecated = j_object_optional(deprecated_attribute.get("@deprecated"))
+            if deprecated is None:
+                continue
+            superseded_by = j_array_optional(deprecated.get("superseded_by"))
+            if not superseded_by:
+                continue
+
+            for reference in superseded_by:
+                base_name = self._supersedes_base_name(j_string(reference))
+                replacement = j_object_optional(dictionary_attributes.get(base_name))
+                if replacement is None:
+                    # The replacement is not a dictionary attribute (for example a
+                    # bare object name). There is no dictionary attribute to anchor
+                    # the reverse marker on, so skip it.
+                    continue
+                self._add_supersedes_marker(replacement, deprecated_name, deprecated)
+
+    def _add_local_attribute_supersedes(self) -> None:
+        """
+        Build the reverse of the "@deprecated.superseded_by" references for
+        attributes deprecated only within a specific class, object, or profile
+        (as opposed to globally in the dictionary). For each such deprecated
+        attribute, attach a "_supersedes" marker onto the replacement attribute in
+        the same item when the replacement is a sibling attribute there.
+
+        This runs after _finish_attributes, so item attributes carry their fully
+        resolved (merged) "@deprecated" annotations. Markers already propagated from
+        the dictionary pass are preserved; _add_supersedes_marker dedupes by name.
+        """
+        if not self.browser_mode:
+            return
+
+        for items in (self._classes, self._objects, self._profiles):
+            for item in items.values():
+                attributes = item_attributes(j_object(item))
+                for deprecated_name, deprecated_attribute in attributes.items():
+                    deprecated_attribute = j_object(deprecated_attribute)
+                    deprecated = j_object_optional(
+                        deprecated_attribute.get("@deprecated")
+                    )
+                    if deprecated is None:
+                        continue
+                    superseded_by = j_array_optional(deprecated.get("superseded_by"))
+                    if not superseded_by:
+                        continue
+
+                    for reference in superseded_by:
+                        base_name = self._supersedes_base_name(j_string(reference))
+                        replacement = j_object_optional(attributes.get(base_name))
+                        if replacement is None:
+                            # The replacement is not a sibling attribute in this item
+                            # (for example a dotted path into another object). There
+                            # is nothing local to anchor the reverse marker on.
+                            continue
+                        self._add_supersedes_marker(
+                            replacement, deprecated_name, deprecated
+                        )
+
+    def _add_item_supersedes(self) -> None:
+        """
+        Build the reverse of the "@deprecated.superseded_by" references for whole
+        classes and objects. For each deprecated class or object that names its
+        replacement class or object, attach an item-level "_supersedes" marker onto
+        the replacement so the schema browser can show, on the live class or object,
+        which deprecated class or object it replaces.
+        """
+        if not self.browser_mode:
+            return
+
+        for items in (self._classes, self._objects):
+            for deprecated_name, item in items.items():
+                item = j_object(item)
+                deprecated = j_object_optional(item.get("@deprecated"))
+                if deprecated is None:
+                    continue
+                superseded_by = j_array_optional(deprecated.get("superseded_by"))
+                if not superseded_by:
+                    continue
+
+                for reference in superseded_by:
+                    # A whole-item replacement may be named as a bare class/object
+                    # name ("finding_info") or as a path into one ("compliance.checks").
+                    # Anchor the reverse marker on the replacement class/object.
+                    base_name = self._supersedes_base_name(j_string(reference))
+                    replacement = self._find_class_or_object(base_name)
+                    if replacement is None:
+                        continue
+                    self._add_supersedes_marker(replacement, deprecated_name, deprecated)
+
+    def _add_enum_value_supersedes(self) -> None:
+        """
+        Build the reverse of the "@deprecated.superseded_by" references for enum
+        values. For each deprecated enum value that names its replacement value (by
+        enum key) within the same attribute, attach a "_supersedes" marker onto the
+        replacement enum value so the schema browser can show, on the live value,
+        which deprecated value it replaces.
+
+        Runs after _finish_attributes, so class/object attributes carry their fully
+        resolved enums. Only same-attribute (sibling) enum-value replacements are
+        handled; references that are not sibling enum keys are skipped.
+        """
+        if not self.browser_mode:
+            return
+
+        for items in (self._classes, self._objects):
+            for item in items.values():
+                attributes = item_attributes(j_object(item))
+                for attribute in attributes.values():
+                    enum = j_object_optional(j_object(attribute).get("enum"))
+                    if enum is None:
+                        continue
+                    self._add_enum_supersedes_for_attribute(enum)
+
+    def _add_enum_supersedes_for_attribute(self, enum: JObject) -> None:
+        for deprecated_key, enum_value in enum.items():
+            enum_value = j_object(enum_value)
+            deprecated = j_object_optional(enum_value.get("@deprecated"))
+            if deprecated is None:
+                continue
+            superseded_by = j_array_optional(deprecated.get("superseded_by"))
+            if not superseded_by:
+                continue
+
+            for reference in superseded_by:
+                replacement_key = j_string(reference)
+                replacement = j_object_optional(enum.get(replacement_key))
+                if replacement is None:
+                    # The replacement is not a sibling enum value of this attribute
+                    # (for example an attribute name). Nothing local to anchor on.
+                    continue
+                self._add_supersedes_marker(replacement, deprecated_key, deprecated)
+
+    def _find_class_or_object(self, name: str) -> JObject | None:
+        """Return the class or object definition with the given name, if any."""
+        found = self._classes.get(name)
+        if found is None:
+            found = self._objects.get(name)
+        return j_object_optional(found)
+
+    def _add_supersedes_marker(
+        self, target: JObject, deprecated_name: str, deprecated: JObject
+    ) -> None:
+        """
+        Attach a "_supersedes" entry naming deprecated_name onto target (a
+        replacement attribute, class, or object definition), deduped by name.
+        """
+        entry: JObject = {"type": deprecated_name}
+        put_non_none(entry, "since", deprecated.get("since"))
+        supersedes = j_array(target.setdefault("_supersedes", []))
+        if not any(
+            j_object(existing).get("type") == deprecated_name
+            for existing in supersedes
+        ):
+            supersedes.append(entry)
+            self._sort_supersedes(supersedes)
+
+    @staticmethod
+    def _supersedes_base_name(reference: str) -> str:
+        """
+        Reduce a superseded_by reference to the attribute it anchors on: the first
+        path segment before a "." or "[". For example "email.uid" -> "email" and
+        "cpu_info_list[*].cores" -> "cpu_info_list".
+        """
+        return reference.split(".", 1)[0].split("[", 1)[0]
+
+    @staticmethod
+    def _sort_supersedes(supersedes: JArray) -> None:
+        supersedes.sort(key=lambda entry: j_string(j_object(entry)["type"]))
 
     def _add_common_dictionary_attribute_links(self) -> None:
         if not self.browser_mode:

--- a/src/ocsf_schema_compiler/compiler.py
+++ b/src/ocsf_schema_compiler/compiler.py
@@ -1,39 +1,33 @@
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, override
+from typing import override
 
 from ocsf_schema_compiler.exceptions import SchemaException
 from ocsf_schema_compiler.jsonish import (
-    JValue,
-    JObject,
     JArray,
-    j_object,
-    j_object_optional,
+    JObject,
+    JValue,
+    deep_copy_j_array,
+    deep_copy_j_object,
+    deep_merge,
     j_array,
     j_array_optional,
+    j_integer,
+    j_object,
+    j_object_optional,
     j_string,
     j_string_optional,
-    j_integer,
     json_type_from_value,
-    deep_copy_j_object,
-    deep_copy_j_array,
-    deep_merge,
     put_non_none,
 )
 from ocsf_schema_compiler.ocsf_utils import (
     is_hidden_class,
     is_hidden_object,
-    requirement_to_rank,
     rank_to_requirement,
-)
-from ocsf_schema_compiler.scoping import (
-    extension_scoped_category_uid,
-    category_scoped_class_uid,
-    class_uid_scoped_type_uid,
-    to_extension_scoped_name,
-    full_name,
+    requirement_to_rank,
 )
 from ocsf_schema_compiler.schema_structure import (
     category_definitions,
@@ -45,13 +39,19 @@ from ocsf_schema_compiler.schema_structure import (
     normalize_item,
     normalize_items,
 )
+from ocsf_schema_compiler.scoping import (
+    category_scoped_class_uid,
+    class_uid_scoped_type_uid,
+    extension_scoped_category_uid,
+    full_name,
+    to_extension_scoped_name,
+)
 from ocsf_schema_compiler.structured_read import (
     read_json_object_file,
-    read_structured_items,
     read_patchable_structured_items,
+    read_structured_items,
 )
 from ocsf_schema_compiler.utils import pretty_json_encode
-
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +333,7 @@ class SchemaCompiler:
         for profile_name, profile in self._profiles.items():
             profile = j_object(profile)
             profile_attributes = item_attributes(profile)
-            for attribute_name in profile_attributes.keys():
+            for attribute_name in profile_attributes:
                 if attribute_name not in dictionary_attributes:
                     raise SchemaException(
                         f'Attribute "{attribute_name}" in base schema profile'
@@ -550,7 +550,7 @@ class SchemaCompiler:
             for profile_name, profile in extension.profiles.items():
                 profile = j_object(profile)
                 profile_attributes = item_attributes(profile)
-                for attribute_name in profile_attributes.keys():
+                for attribute_name in profile_attributes:
                     if (
                         attribute_name not in base_dictionary_attributes
                         and attribute_name not in ext_dictionary_attributes
@@ -756,8 +756,8 @@ class SchemaCompiler:
     def _resolve_extension_includes(self, extensions: list[Extension]) -> None:
         for extension in extensions:
 
-            def path_resolver(file_name: str) -> Path:
-                return self._resolve_extension_include_path(extension, file_name)
+            def path_resolver(file_name: str, ext: Extension = extension) -> Path:
+                return self._resolve_extension_include_path(file_name, ext)
 
             for cls in extension.classes.values():
                 cls = j_object(cls)
@@ -786,7 +786,7 @@ class SchemaCompiler:
                 self._resolve_item_includes(obj_patch, context, path_resolver)
 
     def _resolve_extension_include_path(
-        self, extension: Extension, file_name: str
+        self, file_name: str, extension: Extension
     ) -> Path:
         extension_path = extension.base_path / file_name
         if extension_path.is_file():
@@ -2765,14 +2765,15 @@ class SchemaCompiler:
                     attribute_type_name,
                 )
 
-        if "is_array" in attribute:
-            if attribute["is_array"] != dict_attribute.get("is_array"):
-                raise SchemaException(
-                    f'Attribute "{attribute_name}" in {kind} "{item_name}"'
-                    f' has "is_array" with value {attribute.get("is_array")} that does'
-                    f" not match dictionary attribute value of"
-                    f" {dict_attribute.get('is_array')}"
-                )
+        if "is_array" in attribute and attribute["is_array"] != dict_attribute.get(
+            "is_array"
+        ):
+            raise SchemaException(
+                f'Attribute "{attribute_name}" in {kind} "{item_name}"'
+                f' has "is_array" with value {attribute.get("is_array")} that does'
+                f" not match dictionary attribute value of"
+                f" {dict_attribute.get('is_array')}"
+            )
 
         # TODO: could also check other type constraints
 

--- a/src/ocsf_schema_compiler/jsonish.py
+++ b/src/ocsf_schema_compiler/jsonish.py
@@ -136,20 +136,21 @@ def deep_merge(dest: JObject, source: JObject) -> None:
 
 def get_in(o: JObject, *keys: str) -> JValue:
     v: JValue = None
-    i = 0
     key_count = len(keys)
-    for k in keys:
-        i += 1
+    # stop_i is the top index for current array slice of keys, so starts at 1
+    for stop_i, k in enumerate(keys, 1):
         if k in o:
             v = o[k]
         else:
-            raise KeyNotMappedException(f'Key "{".".join(keys[:i])}" is not mapped')
-        if i < key_count:
+            raise KeyNotMappedException(
+                f'Key "{".".join(keys[:stop_i])}" is not mapped'
+            )
+        if stop_i < key_count:
             if isinstance(v, dict):
                 o = j_object(v)
             else:
                 raise IncorrectTypeException(
-                    f'Expected value of key "{".".join(keys[:i])}" to be an object'
+                    f'Expected value of key "{".".join(keys[:stop_i])}" to be an object'
                     f" but got {json_type_from_value(v)}"
                 )
     return v

--- a/src/ocsf_schema_compiler/structured_read.py
+++ b/src/ocsf_schema_compiler/structured_read.py
@@ -1,15 +1,16 @@
 import json
 import os
+from collections.abc import Callable
 from compression import zstd
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from ocsf_schema_compiler.exceptions import SchemaException
 from ocsf_schema_compiler.jsonish import (
     JObject,
-    json_type_from_value,
     j_object,
     j_string,
+    json_type_from_value,
 )
 
 

--- a/tests/diff.py
+++ b/tests/diff.py
@@ -1,7 +1,7 @@
 import json
+from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Callable
 
 from ocsf_schema_compiler.jsonish import JObject, JValue
 

--- a/tests/test_expected_changes.py
+++ b/tests/test_expected_changes.py
@@ -5,12 +5,13 @@ from sys import stderr
 from typing import override
 
 from diff import (  # pyright: ignore[reportImplicitRelativeImport]
+    MISSING,
+    DiffDictKeys,
+    DiffValue,
     diff_objects,
     formatted_diffs,
-    DiffValue,
-    DiffDictKeys,
-    MISSING,
 )
+
 from ocsf_schema_compiler.compiler import SchemaCompiler
 from ocsf_schema_compiler.jsonish import JObject
 from ocsf_schema_compiler.structured_read import read_json_object_zstandard_file

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -5,12 +5,13 @@ from sys import stderr
 from typing import override
 
 from diff import (  # pyright: ignore[reportImplicitRelativeImport]
+    MISSING,
+    DiffDictKeys,
+    DiffValue,
     diff_objects,
     formatted_diffs,
-    DiffValue,
-    DiffDictKeys,
-    MISSING,
 )
+
 from ocsf_schema_compiler.compiler import SchemaCompiler
 from ocsf_schema_compiler.exceptions import SchemaException
 from ocsf_schema_compiler.jsonish import JObject, get_in
@@ -368,17 +369,14 @@ def legacy_aws_diff_callback(
         # This compiler does not needlessly set object and class "profiles" to null
         return True
 
-    if (
+    # Same as above but now we are at the "objects.<object-name>.profiles" level
+    return (
         key == "profiles"
         and len(path) == 3
         and path[0] == "objects"
         and left_diff == MISSING
         and right_diff is None
-    ):
-        # Same as above but now we are at the "objects.<object-name>.profiles" level
-        return True
-
-    return False
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_schema_structure.py
+++ b/tests/test_schema_structure.py
@@ -61,9 +61,11 @@ class TestSchemaStructure(unittest.TestCase):
             {"types": {"attributes": "not an object"}},
         ]
         for dictionary in dictionaries:
-            with self.subTest(dictionary=dictionary):
-                with self.assertRaisesRegex(SchemaException, "to be an object"):
-                    normalize_dictionary(dictionary, "dictionary")
+            with (
+                self.subTest(dictionary=dictionary),
+                self.assertRaisesRegex(SchemaException, "to be an object"),
+            ):
+                normalize_dictionary(dictionary, "dictionary")
 
     def test_normalize_items_adds_attributes_to_every_item(self):
         items: JObject = {"first": {}, "second": {"attributes": {}}}

--- a/tests/test_supersedes.py
+++ b/tests/test_supersedes.py
@@ -1,15 +1,20 @@
+# These tests exercise the individual reverse-reference passes directly, which are
+# internal to SchemaCompiler.
+# pyright: reportPrivateUsage=false
+
 import unittest
 from pathlib import Path
 
 from ocsf_schema_compiler.compiler import SchemaCompiler
-from ocsf_schema_compiler.jsonish import JObject
+from ocsf_schema_compiler.jsonish import JObject, j_array, j_object, j_string
 
 BASE_DIR = Path(__file__).parent
 
 
 def _make_compiler(browser_mode: bool) -> SchemaCompiler:
-    # The reverse-reference pass operates on self._dictionary directly, so a schema
-    # path is only needed to satisfy the constructor; compile() is never called.
+    # The reverse-reference passes operate on the compiler's dictionary, classes, and
+    # objects directly, so a schema path is only needed to satisfy the constructor;
+    # compile() is never called.
     return SchemaCompiler(
         Path(BASE_DIR, "uncompiled-schemas/ocsf-schema-v1.6.0"),
         browser_mode=browser_mode,
@@ -20,8 +25,24 @@ def _dictionary(attributes: JObject) -> JObject:
     return {"attributes": attributes, "types": {"attributes": {}}}
 
 
-class TestSupersedes(unittest.TestCase):
-    def test_reverse_marker_added_to_replacement(self):
+def _definition(container: JObject, name: str) -> JObject:
+    return j_object(container[name])
+
+
+def _attribute(item: JObject, name: str) -> JObject:
+    return j_object(j_object(item["attributes"])[name])
+
+
+def _supersedes(target: JObject) -> list[JObject]:
+    return [j_object(entry) for entry in j_array(target["_supersedes"])]
+
+
+def _superseded_names(target: JObject) -> list[str]:
+    return [j_string(entry["type"]) for entry in _supersedes(target)]
+
+
+class TestDictionaryAttributeSupersedes(unittest.TestCase):
+    def test_reverse_marker_added_to_replacement(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._dictionary = _dictionary(
             {
@@ -39,14 +60,15 @@ class TestSupersedes(unittest.TestCase):
 
         compiler._add_dictionary_attribute_supersedes()
 
-        attributes = compiler._dictionary["attributes"]
-        self.assertNotIn("_supersedes", attributes["app"])
+        attributes = j_object(compiler._dictionary["attributes"])
+        # The deprecated attribute itself is not marked.
+        self.assertNotIn("_supersedes", _definition(attributes, "app"))
         self.assertEqual(
-            attributes["application"]["_supersedes"],
+            _supersedes(_definition(attributes, "application")),
             [{"type": "app", "since": "1.9.0"}],
         )
 
-    def test_multiple_replacements(self):
+    def test_multiple_replacements(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._dictionary = _dictionary(
             {
@@ -65,17 +87,17 @@ class TestSupersedes(unittest.TestCase):
 
         compiler._add_dictionary_attribute_supersedes()
 
-        attributes = compiler._dictionary["attributes"]
+        attributes = j_object(compiler._dictionary["attributes"])
         self.assertEqual(
-            attributes["model"]["_supersedes"],
+            _supersedes(_definition(attributes, "model")),
             [{"type": "cpu_type", "since": "1.9.0"}],
         )
         self.assertEqual(
-            attributes["vendor_name"]["_supersedes"],
+            _supersedes(_definition(attributes, "vendor_name")),
             [{"type": "cpu_type", "since": "1.9.0"}],
         )
 
-    def test_aggregates_multiple_deprecated_onto_one_replacement(self):
+    def test_aggregates_multiple_deprecated_onto_one_replacement(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._dictionary = _dictionary(
             {
@@ -101,11 +123,14 @@ class TestSupersedes(unittest.TestCase):
 
         compiler._add_dictionary_attribute_supersedes()
 
-        supersedes = compiler._dictionary["attributes"]["related_cwes"]["_supersedes"]
+        attributes = j_object(compiler._dictionary["attributes"])
         # Sorted by deprecated attribute name.
-        self.assertEqual([entry["type"] for entry in supersedes], ["cwe_uid", "cwe_url"])
+        self.assertEqual(
+            _superseded_names(_definition(attributes, "related_cwes")),
+            ["cwe_uid", "cwe_url"],
+        )
 
-    def test_dotted_path_anchors_on_base_attribute(self):
+    def test_dotted_path_anchors_on_base_attribute(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._dictionary = _dictionary(
             {
@@ -123,9 +148,12 @@ class TestSupersedes(unittest.TestCase):
 
         compiler._add_dictionary_attribute_supersedes()
 
-        self.assertIn("_supersedes", compiler._dictionary["attributes"]["email"])
+        attributes = j_object(compiler._dictionary["attributes"])
+        self.assertEqual(
+            _superseded_names(_definition(attributes, "email")), ["email_uid"]
+        )
 
-    def test_unresolvable_replacement_is_skipped(self):
+    def test_unresolvable_replacement_is_skipped(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._dictionary = _dictionary(
             {
@@ -140,15 +168,14 @@ class TestSupersedes(unittest.TestCase):
             }
         )
 
-        # finding_info is not a dictionary attribute here, so there is nothing to anchor
-        # the reverse marker on. This must not raise.
+        # finding_info is not a dictionary attribute here, so there is nothing to
+        # anchor the reverse marker on. This must not raise.
         compiler._add_dictionary_attribute_supersedes()
 
-        self.assertNotIn(
-            "_supersedes", compiler._dictionary["attributes"]["finding"]
-        )
+        attributes = j_object(compiler._dictionary["attributes"])
+        self.assertNotIn("_supersedes", _definition(attributes, "finding"))
 
-    def test_no_marker_without_browser_mode(self):
+    def test_no_marker_without_browser_mode(self) -> None:
         compiler = _make_compiler(browser_mode=False)
         compiler._dictionary = _dictionary(
             {
@@ -166,11 +193,10 @@ class TestSupersedes(unittest.TestCase):
 
         compiler._add_dictionary_attribute_supersedes()
 
-        self.assertNotIn(
-            "_supersedes", compiler._dictionary["attributes"]["application"]
-        )
+        attributes = j_object(compiler._dictionary["attributes"])
+        self.assertNotIn("_supersedes", _definition(attributes, "application"))
 
-    def test_deprecated_without_superseded_by_is_ignored(self):
+    def test_deprecated_without_superseded_by_is_ignored(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._dictionary = _dictionary(
             {
@@ -187,10 +213,12 @@ class TestSupersedes(unittest.TestCase):
 
         compiler._add_dictionary_attribute_supersedes()
 
-        self.assertNotIn("_supersedes", compiler._dictionary["attributes"]["other"])
+        attributes = j_object(compiler._dictionary["attributes"])
+        self.assertNotIn("_supersedes", _definition(attributes, "other"))
 
-    def test_empty_superseded_by_creates_no_marker(self):
-        # An empty superseded_by means "removed with no replacement": no reverse marker.
+    def test_empty_superseded_by_creates_no_marker(self) -> None:
+        # An empty superseded_by means "removed with no replacement": no reverse
+        # marker is created anywhere.
         compiler = _make_compiler(browser_mode=True)
         compiler._dictionary = _dictionary(
             {
@@ -208,12 +236,13 @@ class TestSupersedes(unittest.TestCase):
 
         compiler._add_dictionary_attribute_supersedes()
 
-        self.assertNotIn("_supersedes", compiler._dictionary["attributes"]["other"])
-        self.assertNotIn("_supersedes", compiler._dictionary["attributes"]["removed"])
+        attributes = j_object(compiler._dictionary["attributes"])
+        self.assertNotIn("_supersedes", _definition(attributes, "other"))
+        self.assertNotIn("_supersedes", _definition(attributes, "removed"))
 
 
 class TestLocalAttributeSupersedes(unittest.TestCase):
-    def test_sibling_replacement_in_same_item(self):
+    def test_replacement_in_same_item(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._classes = {
             "user_access": {
@@ -234,18 +263,15 @@ class TestLocalAttributeSupersedes(unittest.TestCase):
 
         compiler._add_local_attribute_supersedes()
 
-        resources = compiler._classes["user_access"]["attributes"]["resources"]
+        user_access = _definition(compiler._classes, "user_access")
         self.assertEqual(
-            resources["_supersedes"],
+            _supersedes(_attribute(user_access, "resources")),
             [{"type": "resource", "since": "1.5.0"}],
         )
         # The deprecated attribute itself is not marked.
-        self.assertNotIn(
-            "_supersedes",
-            compiler._classes["user_access"]["attributes"]["resource"],
-        )
+        self.assertNotIn("_supersedes", _attribute(user_access, "resource"))
 
-    def test_non_sibling_replacement_is_skipped(self):
+    def test_replacement_outside_the_item_is_skipped(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._classes = {
             "email_activity": {
@@ -263,15 +289,14 @@ class TestLocalAttributeSupersedes(unittest.TestCase):
         compiler._objects = {}
         compiler._profiles = {}
 
-        # email is not a sibling attribute here, so nothing local to anchor on.
+        # email is not declared in this class, so there is nothing local to anchor on.
+        # A local deprecation must not leak a marker into another context.
         compiler._add_local_attribute_supersedes()
 
-        self.assertNotIn(
-            "_supersedes",
-            compiler._classes["email_activity"]["attributes"]["email_uid"],
-        )
+        email_activity = _definition(compiler._classes, "email_activity")
+        self.assertNotIn("_supersedes", _attribute(email_activity, "email_uid"))
 
-    def test_no_marker_without_browser_mode(self):
+    def test_no_marker_without_browser_mode(self) -> None:
         compiler = _make_compiler(browser_mode=False)
         compiler._classes = {
             "c": {
@@ -293,18 +318,18 @@ class TestLocalAttributeSupersedes(unittest.TestCase):
         compiler._add_local_attribute_supersedes()
 
         self.assertNotIn(
-            "_supersedes", compiler._classes["c"]["attributes"]["new_attr"]
+            "_supersedes", _attribute(_definition(compiler._classes, "c"), "new_attr")
         )
 
 
 class TestItemSupersedes(unittest.TestCase):
-    def test_class_supersedes_class(self):
+    def test_class_supersedes_class(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._classes = {
             "user_access": {
                 "attributes": {},
                 "@deprecated": {
-                    "message": "Use User Management instead.",
+                    "message": "Use user_management instead.",
                     "since": "1.6.0",
                     "superseded_by": ["user_management"],
                 },
@@ -316,17 +341,17 @@ class TestItemSupersedes(unittest.TestCase):
         compiler._add_item_supersedes()
 
         self.assertEqual(
-            compiler._classes["user_management"]["_supersedes"],
+            _supersedes(_definition(compiler._classes, "user_management")),
             [{"type": "user_access", "since": "1.6.0"}],
         )
 
-    def test_multiple_deprecated_classes_aggregate_on_replacement(self):
+    def test_multiple_deprecated_classes_aggregate_on_replacement(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._classes = {
             "file_query": {
                 "attributes": {},
                 "@deprecated": {
-                    "message": "Use Live Evidence Info.",
+                    "message": "Use evidence_info instead.",
                     "since": "1.1.0",
                     "superseded_by": ["evidence_info"],
                 },
@@ -334,7 +359,7 @@ class TestItemSupersedes(unittest.TestCase):
             "job_query": {
                 "attributes": {},
                 "@deprecated": {
-                    "message": "Use Live Evidence Info.",
+                    "message": "Use evidence_info instead.",
                     "since": "1.1.0",
                     "superseded_by": ["evidence_info"],
                 },
@@ -346,18 +371,18 @@ class TestItemSupersedes(unittest.TestCase):
         compiler._add_item_supersedes()
 
         self.assertEqual(
-            [e["type"] for e in compiler._classes["evidence_info"]["_supersedes"]],
+            _superseded_names(_definition(compiler._classes, "evidence_info")),
             ["file_query", "job_query"],
         )
 
-    def test_object_supersedes_object(self):
+    def test_object_supersedes_object(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._classes = {}
         compiler._objects = {
             "finding": {
                 "attributes": {},
                 "@deprecated": {
-                    "message": "Use finding_info.",
+                    "message": "Use finding_info instead.",
                     "since": "1.0.0",
                     "superseded_by": ["finding_info"],
                 },
@@ -368,17 +393,17 @@ class TestItemSupersedes(unittest.TestCase):
         compiler._add_item_supersedes()
 
         self.assertEqual(
-            compiler._objects["finding_info"]["_supersedes"],
+            _supersedes(_definition(compiler._objects, "finding_info")),
             [{"type": "finding", "since": "1.0.0"}],
         )
 
-    def test_unresolvable_replacement_is_skipped(self):
+    def test_unresolvable_replacement_is_skipped(self) -> None:
         compiler = _make_compiler(browser_mode=True)
         compiler._classes = {
             "security_finding": {
                 "attributes": {},
                 "@deprecated": {
-                    "message": "Use specific classes.",
+                    "message": "Use the specific finding classes instead.",
                     "since": "1.1.0",
                     "superseded_by": ["nonexistent_class"],
                 },
@@ -389,19 +414,46 @@ class TestItemSupersedes(unittest.TestCase):
         # Must not raise; no marker created anywhere.
         compiler._add_item_supersedes()
 
-        self.assertNotIn("_supersedes", compiler._classes["security_finding"])
+        self.assertNotIn(
+            "_supersedes", _definition(compiler._classes, "security_finding")
+        )
+
+    def test_no_marker_without_browser_mode(self) -> None:
+        compiler = _make_compiler(browser_mode=False)
+        compiler._classes = {
+            "user_access": {
+                "attributes": {},
+                "@deprecated": {
+                    "message": "Use user_management instead.",
+                    "since": "1.6.0",
+                    "superseded_by": ["user_management"],
+                },
+            },
+            "user_management": {"attributes": {}},
+        }
+        compiler._objects = {}
+
+        compiler._add_item_supersedes()
+
+        self.assertNotIn(
+            "_supersedes", _definition(compiler._classes, "user_management")
+        )
 
 
 class TestEnumValueSupersedes(unittest.TestCase):
-    def _compiler_with_enum(self, enum):
-        compiler = _make_compiler(browser_mode=True)
+    def _compiler_with_enum(
+        self, enum: JObject, browser_mode: bool = True
+    ) -> SchemaCompiler:
+        compiler = _make_compiler(browser_mode=browser_mode)
         compiler._classes = {}
-        compiler._objects = {
-            "reg_value": {"attributes": {"type_id": {"enum": enum}}}
-        }
+        compiler._objects = {"reg_value": {"attributes": {"type_id": {"enum": enum}}}}
         return compiler
 
-    def test_sibling_enum_value_replacement(self):
+    def _enum(self, compiler: SchemaCompiler) -> JObject:
+        reg_value = _definition(compiler._objects, "reg_value")
+        return j_object(_attribute(reg_value, "type_id")["enum"])
+
+    def test_replacement_value_in_same_enum(self) -> None:
         compiler = self._compiler_with_enum(
             {
                 "8": {"caption": "REG_QWORD"},
@@ -418,13 +470,15 @@ class TestEnumValueSupersedes(unittest.TestCase):
 
         compiler._add_enum_value_supersedes()
 
-        enum = compiler._objects["reg_value"]["attributes"]["type_id"]["enum"]
-        self.assertEqual(enum["8"]["_supersedes"], [{"type": "9", "since": "1.6.0"}])
+        enum = self._enum(compiler)
+        self.assertEqual(
+            _supersedes(_definition(enum, "8")), [{"type": "9", "since": "1.6.0"}]
+        )
         # The deprecated value itself is not marked.
-        self.assertNotIn("_supersedes", enum["9"])
+        self.assertNotIn("_supersedes", _definition(enum, "9"))
 
-    def test_non_sibling_reference_is_skipped(self):
-        # superseded_by names an attribute, not a sibling enum key.
+    def test_reference_outside_the_enum_is_skipped(self) -> None:
+        # superseded_by names an attribute rather than a value in the same enum.
         compiler = self._compiler_with_enum(
             {
                 "4": {
@@ -440,10 +494,9 @@ class TestEnumValueSupersedes(unittest.TestCase):
 
         compiler._add_enum_value_supersedes()
 
-        enum = compiler._objects["reg_value"]["attributes"]["type_id"]["enum"]
-        self.assertNotIn("_supersedes", enum["4"])
+        self.assertNotIn("_supersedes", _definition(self._enum(compiler), "4"))
 
-    def test_no_marker_without_browser_mode(self):
+    def test_no_marker_without_browser_mode(self) -> None:
         compiler = self._compiler_with_enum(
             {
                 "8": {"caption": "REG_QWORD"},
@@ -455,15 +508,14 @@ class TestEnumValueSupersedes(unittest.TestCase):
                         "superseded_by": ["8"],
                     },
                 },
-            }
+            },
+            browser_mode=False,
         )
-        compiler.browser_mode = False
 
         compiler._add_enum_value_supersedes()
 
-        enum = compiler._objects["reg_value"]["attributes"]["type_id"]["enum"]
-        self.assertNotIn("_supersedes", enum["8"])
+        self.assertNotIn("_supersedes", _definition(self._enum(compiler), "8"))
 
 
 if __name__ == "__main__":
-    unittest.main()
+    _ = unittest.main()

--- a/tests/test_supersedes.py
+++ b/tests/test_supersedes.py
@@ -1,0 +1,469 @@
+import unittest
+from pathlib import Path
+
+from ocsf_schema_compiler.compiler import SchemaCompiler
+from ocsf_schema_compiler.jsonish import JObject
+
+BASE_DIR = Path(__file__).parent
+
+
+def _make_compiler(browser_mode: bool) -> SchemaCompiler:
+    # The reverse-reference pass operates on self._dictionary directly, so a schema
+    # path is only needed to satisfy the constructor; compile() is never called.
+    return SchemaCompiler(
+        Path(BASE_DIR, "uncompiled-schemas/ocsf-schema-v1.6.0"),
+        browser_mode=browser_mode,
+    )
+
+
+def _dictionary(attributes: JObject) -> JObject:
+    return {"attributes": attributes, "types": {"attributes": {}}}
+
+
+class TestSupersedes(unittest.TestCase):
+    def test_reverse_marker_added_to_replacement(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._dictionary = _dictionary(
+            {
+                "app": {
+                    "caption": "Application",
+                    "@deprecated": {
+                        "message": "Use application instead.",
+                        "since": "1.9.0",
+                        "superseded_by": ["application"],
+                    },
+                },
+                "application": {"caption": "Application"},
+            }
+        )
+
+        compiler._add_dictionary_attribute_supersedes()
+
+        attributes = compiler._dictionary["attributes"]
+        self.assertNotIn("_supersedes", attributes["app"])
+        self.assertEqual(
+            attributes["application"]["_supersedes"],
+            [{"type": "app", "since": "1.9.0"}],
+        )
+
+    def test_multiple_replacements(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._dictionary = _dictionary(
+            {
+                "cpu_type": {
+                    "caption": "Processor Type",
+                    "@deprecated": {
+                        "message": "Use model and vendor_name instead.",
+                        "since": "1.9.0",
+                        "superseded_by": ["model", "vendor_name"],
+                    },
+                },
+                "model": {"caption": "Model"},
+                "vendor_name": {"caption": "Vendor Name"},
+            }
+        )
+
+        compiler._add_dictionary_attribute_supersedes()
+
+        attributes = compiler._dictionary["attributes"]
+        self.assertEqual(
+            attributes["model"]["_supersedes"],
+            [{"type": "cpu_type", "since": "1.9.0"}],
+        )
+        self.assertEqual(
+            attributes["vendor_name"]["_supersedes"],
+            [{"type": "cpu_type", "since": "1.9.0"}],
+        )
+
+    def test_aggregates_multiple_deprecated_onto_one_replacement(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._dictionary = _dictionary(
+            {
+                "cwe_uid": {
+                    "caption": "CWE UID",
+                    "@deprecated": {
+                        "message": "Use related_cwes instead.",
+                        "since": "1.1.0",
+                        "superseded_by": ["related_cwes"],
+                    },
+                },
+                "cwe_url": {
+                    "caption": "CWE URL",
+                    "@deprecated": {
+                        "message": "Use related_cwes instead.",
+                        "since": "1.1.0",
+                        "superseded_by": ["related_cwes"],
+                    },
+                },
+                "related_cwes": {"caption": "Related CWEs"},
+            }
+        )
+
+        compiler._add_dictionary_attribute_supersedes()
+
+        supersedes = compiler._dictionary["attributes"]["related_cwes"]["_supersedes"]
+        # Sorted by deprecated attribute name.
+        self.assertEqual([entry["type"] for entry in supersedes], ["cwe_uid", "cwe_url"])
+
+    def test_dotted_path_anchors_on_base_attribute(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._dictionary = _dictionary(
+            {
+                "email_uid": {
+                    "caption": "Email UID",
+                    "@deprecated": {
+                        "message": "Use email.uid instead.",
+                        "since": "1.4.0",
+                        "superseded_by": ["email.uid"],
+                    },
+                },
+                "email": {"caption": "Email"},
+            }
+        )
+
+        compiler._add_dictionary_attribute_supersedes()
+
+        self.assertIn("_supersedes", compiler._dictionary["attributes"]["email"])
+
+    def test_unresolvable_replacement_is_skipped(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._dictionary = _dictionary(
+            {
+                "finding": {
+                    "caption": "Finding",
+                    "@deprecated": {
+                        "message": "Use the finding_info object instead.",
+                        "since": "1.0.0",
+                        "superseded_by": ["finding_info"],
+                    },
+                },
+            }
+        )
+
+        # finding_info is not a dictionary attribute here, so there is nothing to anchor
+        # the reverse marker on. This must not raise.
+        compiler._add_dictionary_attribute_supersedes()
+
+        self.assertNotIn(
+            "_supersedes", compiler._dictionary["attributes"]["finding"]
+        )
+
+    def test_no_marker_without_browser_mode(self):
+        compiler = _make_compiler(browser_mode=False)
+        compiler._dictionary = _dictionary(
+            {
+                "app": {
+                    "caption": "Application",
+                    "@deprecated": {
+                        "message": "Use application instead.",
+                        "since": "1.9.0",
+                        "superseded_by": ["application"],
+                    },
+                },
+                "application": {"caption": "Application"},
+            }
+        )
+
+        compiler._add_dictionary_attribute_supersedes()
+
+        self.assertNotIn(
+            "_supersedes", compiler._dictionary["attributes"]["application"]
+        )
+
+    def test_deprecated_without_superseded_by_is_ignored(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._dictionary = _dictionary(
+            {
+                "legacy": {
+                    "caption": "Legacy",
+                    "@deprecated": {
+                        "message": "No replacement.",
+                        "since": "1.0.0",
+                    },
+                },
+                "other": {"caption": "Other"},
+            }
+        )
+
+        compiler._add_dictionary_attribute_supersedes()
+
+        self.assertNotIn("_supersedes", compiler._dictionary["attributes"]["other"])
+
+    def test_empty_superseded_by_creates_no_marker(self):
+        # An empty superseded_by means "removed with no replacement": no reverse marker.
+        compiler = _make_compiler(browser_mode=True)
+        compiler._dictionary = _dictionary(
+            {
+                "removed": {
+                    "caption": "Removed",
+                    "@deprecated": {
+                        "message": "Removed with no replacement.",
+                        "since": "1.0.0",
+                        "superseded_by": [],
+                    },
+                },
+                "other": {"caption": "Other"},
+            }
+        )
+
+        compiler._add_dictionary_attribute_supersedes()
+
+        self.assertNotIn("_supersedes", compiler._dictionary["attributes"]["other"])
+        self.assertNotIn("_supersedes", compiler._dictionary["attributes"]["removed"])
+
+
+class TestLocalAttributeSupersedes(unittest.TestCase):
+    def test_sibling_replacement_in_same_item(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._classes = {
+            "user_access": {
+                "attributes": {
+                    "resource": {
+                        "@deprecated": {
+                            "message": "Use resources instead.",
+                            "since": "1.5.0",
+                            "superseded_by": ["resources"],
+                        }
+                    },
+                    "resources": {"caption": "Resources"},
+                }
+            }
+        }
+        compiler._objects = {}
+        compiler._profiles = {}
+
+        compiler._add_local_attribute_supersedes()
+
+        resources = compiler._classes["user_access"]["attributes"]["resources"]
+        self.assertEqual(
+            resources["_supersedes"],
+            [{"type": "resource", "since": "1.5.0"}],
+        )
+        # The deprecated attribute itself is not marked.
+        self.assertNotIn(
+            "_supersedes",
+            compiler._classes["user_access"]["attributes"]["resource"],
+        )
+
+    def test_non_sibling_replacement_is_skipped(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._classes = {
+            "email_activity": {
+                "attributes": {
+                    "email_uid": {
+                        "@deprecated": {
+                            "message": "Use email.uid instead.",
+                            "since": "1.4.0",
+                            "superseded_by": ["email.uid"],
+                        }
+                    }
+                }
+            }
+        }
+        compiler._objects = {}
+        compiler._profiles = {}
+
+        # email is not a sibling attribute here, so nothing local to anchor on.
+        compiler._add_local_attribute_supersedes()
+
+        self.assertNotIn(
+            "_supersedes",
+            compiler._classes["email_activity"]["attributes"]["email_uid"],
+        )
+
+    def test_no_marker_without_browser_mode(self):
+        compiler = _make_compiler(browser_mode=False)
+        compiler._classes = {
+            "c": {
+                "attributes": {
+                    "old": {
+                        "@deprecated": {
+                            "message": "Use new_attr instead.",
+                            "since": "1.0.0",
+                            "superseded_by": ["new_attr"],
+                        }
+                    },
+                    "new_attr": {"caption": "New"},
+                }
+            }
+        }
+        compiler._objects = {}
+        compiler._profiles = {}
+
+        compiler._add_local_attribute_supersedes()
+
+        self.assertNotIn(
+            "_supersedes", compiler._classes["c"]["attributes"]["new_attr"]
+        )
+
+
+class TestItemSupersedes(unittest.TestCase):
+    def test_class_supersedes_class(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._classes = {
+            "user_access": {
+                "attributes": {},
+                "@deprecated": {
+                    "message": "Use User Management instead.",
+                    "since": "1.6.0",
+                    "superseded_by": ["user_management"],
+                },
+            },
+            "user_management": {"attributes": {}},
+        }
+        compiler._objects = {}
+
+        compiler._add_item_supersedes()
+
+        self.assertEqual(
+            compiler._classes["user_management"]["_supersedes"],
+            [{"type": "user_access", "since": "1.6.0"}],
+        )
+
+    def test_multiple_deprecated_classes_aggregate_on_replacement(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._classes = {
+            "file_query": {
+                "attributes": {},
+                "@deprecated": {
+                    "message": "Use Live Evidence Info.",
+                    "since": "1.1.0",
+                    "superseded_by": ["evidence_info"],
+                },
+            },
+            "job_query": {
+                "attributes": {},
+                "@deprecated": {
+                    "message": "Use Live Evidence Info.",
+                    "since": "1.1.0",
+                    "superseded_by": ["evidence_info"],
+                },
+            },
+            "evidence_info": {"attributes": {}},
+        }
+        compiler._objects = {}
+
+        compiler._add_item_supersedes()
+
+        self.assertEqual(
+            [e["type"] for e in compiler._classes["evidence_info"]["_supersedes"]],
+            ["file_query", "job_query"],
+        )
+
+    def test_object_supersedes_object(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._classes = {}
+        compiler._objects = {
+            "finding": {
+                "attributes": {},
+                "@deprecated": {
+                    "message": "Use finding_info.",
+                    "since": "1.0.0",
+                    "superseded_by": ["finding_info"],
+                },
+            },
+            "finding_info": {"attributes": {}},
+        }
+
+        compiler._add_item_supersedes()
+
+        self.assertEqual(
+            compiler._objects["finding_info"]["_supersedes"],
+            [{"type": "finding", "since": "1.0.0"}],
+        )
+
+    def test_unresolvable_replacement_is_skipped(self):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._classes = {
+            "security_finding": {
+                "attributes": {},
+                "@deprecated": {
+                    "message": "Use specific classes.",
+                    "since": "1.1.0",
+                    "superseded_by": ["nonexistent_class"],
+                },
+            }
+        }
+        compiler._objects = {}
+
+        # Must not raise; no marker created anywhere.
+        compiler._add_item_supersedes()
+
+        self.assertNotIn("_supersedes", compiler._classes["security_finding"])
+
+
+class TestEnumValueSupersedes(unittest.TestCase):
+    def _compiler_with_enum(self, enum):
+        compiler = _make_compiler(browser_mode=True)
+        compiler._classes = {}
+        compiler._objects = {
+            "reg_value": {"attributes": {"type_id": {"enum": enum}}}
+        }
+        return compiler
+
+    def test_sibling_enum_value_replacement(self):
+        compiler = self._compiler_with_enum(
+            {
+                "8": {"caption": "REG_QWORD"},
+                "9": {
+                    "caption": "REG_QWORD_LITTLE_ENDIAN",
+                    "@deprecated": {
+                        "message": "Use REG_QWORD instead.",
+                        "since": "1.6.0",
+                        "superseded_by": ["8"],
+                    },
+                },
+            }
+        )
+
+        compiler._add_enum_value_supersedes()
+
+        enum = compiler._objects["reg_value"]["attributes"]["type_id"]["enum"]
+        self.assertEqual(enum["8"]["_supersedes"], [{"type": "9", "since": "1.6.0"}])
+        # The deprecated value itself is not marked.
+        self.assertNotIn("_supersedes", enum["9"])
+
+    def test_non_sibling_reference_is_skipped(self):
+        # superseded_by names an attribute, not a sibling enum key.
+        compiler = self._compiler_with_enum(
+            {
+                "4": {
+                    "caption": "Suppressed",
+                    "@deprecated": {
+                        "message": "Use status_id instead.",
+                        "since": "1.4.0",
+                        "superseded_by": ["status_id"],
+                    },
+                },
+            }
+        )
+
+        compiler._add_enum_value_supersedes()
+
+        enum = compiler._objects["reg_value"]["attributes"]["type_id"]["enum"]
+        self.assertNotIn("_supersedes", enum["4"])
+
+    def test_no_marker_without_browser_mode(self):
+        compiler = self._compiler_with_enum(
+            {
+                "8": {"caption": "REG_QWORD"},
+                "9": {
+                    "caption": "REG_QWORD_LITTLE_ENDIAN",
+                    "@deprecated": {
+                        "message": "Use REG_QWORD instead.",
+                        "since": "1.6.0",
+                        "superseded_by": ["8"],
+                    },
+                },
+            }
+        )
+        compiler.browser_mode = False
+
+        compiler._add_enum_value_supersedes()
+
+        enum = compiler._objects["reg_value"]["attributes"]["type_id"]["enum"]
+        self.assertNotIn("_supersedes", enum["8"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Summary
OCSF @deprecated blocks tell you what a deprecated definition was replaced by. Nothing tells you the inverse: looking at a live attribute, there is no way to know it is the replacement for something deprecated. This PR adds a browser-mode compilation pass that derives that reverse reference.

Given a deprecation that names its replacement:

```
"path": {
  "@deprecated": {
    "message": "Use the <code>path</code> attribute of the file objects in the <code>files</code> array instead.",
    "since": "1.5.0",
    "superseded_by": ["files"]
  }
}
```
the compiler emits a _supersedes marker on the replacement:

```
"files": {
  "_supersedes": [{"type": "path", "since": "1.5.0"}]
}
```
The [OCSF Server](https://github.com/ocsf/ocsf-server) consumes this to render a "Supersedes deprecated path" marker on the live definition, so the relationship is visible by default rather than requiring the user to find the deprecated definition first.

This is the compiler half of the change. It depends on superseded_by being added to the @deprecated metaschema in [ocsf-schema](https://github.com/ocsf/ocsf-schema), and is consumed by a corresponding ocsf-server change.

#### Related PRs

1. https://github.com/ocsf/ocsf-schema/pull/1708
2. https://github.com/ocsf/ocsf-schema/pull/1707